### PR TITLE
feat(typeahead): Working typeahead no styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,58 @@
-# Vue 3 + Vite
+# Lob Vue Address Autocomplete Components
 
-This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+## Features
 
-## Recommended IDE Setup
+ This is a very lightweight component that uses the Lob Autocomplete API in order to simplify the process of adding in a search autocomplete bar. Check out the Autocomplete API for more configuration options on [Postman](https://www.postman.com/lobteam/workspace/lob-public-workspace/overview) or [Lob Documentation](https://docs.lob.com/).
 
-- [VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+ As always if this front end component doesn't suit your bootstrapped needs, feel free to check out the aformentioned links above to have more control over the look and feel of your address autocomplete and verification needs :)
+
+## Install
+
+```bash
+npm install --save @lob/vue-address-autocomplete
+```
+
+## Address Autocomplete Search Bar Demo Code 
+
+```jsx
+<template>
+<div>
+  <AddressAutocomplete apiKey="YOUR_API_KEY_HERE" :addresses="addresses" @selectItem="selectItem" @newSuggestions="addNewSuggestions" />
+  <div class="column column-40">
+  <pre><code>{{selection}}</code></pre>
+</div>
+  </div>
+</template>
+
+<script>
+import AddressAutocomplete from @lob/vue-address-autocomplete'
+export default {
+  components: {
+    AddressAutocomplete
+  },
+  data() {
+    return {
+      addresses: [],
+      selection: ''
+    }
+  },
+  methods: {
+		selectItem(item) {
+			this.selection = item;
+		},
+    addNewSuggestions(suggestedAddresses) {
+      this.addresses = suggestedAddresses;
+    }
+	}
+};
+</script>
+```
 
 
-## How to test locally
+## How to Build and publish
 
 Run 
 ```
 npm run build
-npm link
+npm publish
 ```
-
-and then in a different project repo you can
-``` 
-run npm link "@lob/vue-address-autocomplete"
-```
-
-At which point you can now test the repo locally 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badge.fury.io/js/@lob%2Fvue-address-autocomplete.svg)](https://badge.fury.io/js/@lob%2Fvue-address-autocomplete)
+
 # Lob Vue Address Autocomplete Components
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export default {
   methods: {
     selectItem(item) {
       this.selection = item;
-		},
+    },
     addNewSuggestions(suggestedAddresses) {
       this.addresses = suggestedAddresses;
     }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save @lob/vue-address-autocomplete
 
 ## Address Autocomplete Search Bar Demo Code 
 
-```jsx
+```javascript
 <template>
   <div>
     <AddressAutocomplete apiKey="YOUR_API_KEY_HERE" :addresses="addresses" @selectItem="selectItem" @newSuggestions="addNewSuggestions" />
@@ -39,7 +39,7 @@ export default {
     }
   },
   methods: {
-		selectItem(item) {
+    selectItem(item) {
 			this.selection = item;
 		},
     addNewSuggestions(suggestedAddresses) {

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ export default {
   },
   methods: {
     selectItem(item) {
-			this.selection = item;
+      this.selection = item;
 		},
     addNewSuggestions(suggestedAddresses) {
       this.addresses = suggestedAddresses;
     }
-	}
+  }
 };
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ npm install --save @lob/vue-address-autocomplete
 
 ```jsx
 <template>
-<div>
-  <AddressAutocomplete apiKey="YOUR_API_KEY_HERE" :addresses="addresses" @selectItem="selectItem" @newSuggestions="addNewSuggestions" />
-  <div class="column column-40">
-  <pre><code>{{selection}}</code></pre>
-</div>
+  <div>
+    <AddressAutocomplete apiKey="YOUR_API_KEY_HERE" :addresses="addresses" @selectItem="selectItem" @newSuggestions="addNewSuggestions" />
+    <div class="column column-40">
+      <pre><code>{{selection}}</code></pre>
+    </div>
   </div>
 </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@lob/vue-address-autocomplete",
       "version": "0.0.6",
       "dependencies": {
+        "base-64": "^1.0.0",
         "path": "^0.12.7",
         "vue": "^3.2.25"
       },
@@ -141,6 +142,11 @@
       "version": "3.2.31",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
       "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/csstype": {
       "version": "2.6.20",
@@ -860,6 +866,11 @@
       "version": "3.2.31",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
       "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
+    },
+    "base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "csstype": {
       "version": "2.6.20",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "build": "vite build",
     "preview": "vite preview"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lob/vue-address-autocomplete.git"
+  },
   "dependencies": {
     "base-64": "^1.0.0",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "base-64": "^1.0.0",
     "path": "^0.12.7",
     "vue": "^3.2.25"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <AddressAutocomplete apiKey="live_f1509d4894ea4b21c4568fb87b6fb21d293" />
+  <AddressAutocomplete apiKey="api_key_here" />
 </template>
 
 <script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,23 @@
+<template>
+  <AddressAutocomplete apiKey="live_f1509d4894ea4b21c4568fb87b6fb21d293" />
+</template>
+
+<script>
+import AddressAutocomplete from './components/AddressAutocomplete.vue'
+export default {
+  components: {
+    AddressAutocomplete
+  }
+};
+</script>
+
+<style>
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 60px;
+}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,10 @@
 <template>
-  <AddressAutocomplete apiKey="api_key_here" />
+<div>
+  <AddressAutocomplete apiKey="YOUR_API_KEY_HERE" :addresses="addresses" @selectItem="selectItem" @newSuggestions="addNewSuggestions" />
+  <div class="column column-40">
+  <pre><code>{{selection}}</code></pre>
+</div>
+  </div>
 </template>
 
 <script>
@@ -7,17 +12,20 @@ import AddressAutocomplete from './components/AddressAutocomplete.vue'
 export default {
   components: {
     AddressAutocomplete
-  }
+  },
+  data() {
+    return {
+      addresses: [],
+      selection: ''
+    }
+  },
+  methods: {
+		selectItem(item) {
+			this.selection = item;
+		},
+    addNewSuggestions(suggestedAddresses) {
+      this.addresses = suggestedAddresses;
+    }
+	}
 };
 </script>
-
-<style>
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
-}
-</style>

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,57 @@
+// External Dependencies
+import base64 from 'base-64'
+
+export const postAutocompleteAddress = (
+  apiKey,
+  addressPrefix,
+  additionalAddressData
+) => {
+  const url =
+    'https://api.lob.com/v1/us_autocompletions?valid_addresses=true&case=proper'
+  const init = {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${base64.encode(apiKey + ':')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      address_prefix: addressPrefix,
+      ...additionalAddressData
+    })
+  }
+
+  return fetch(url, init)
+}
+
+export const postVerifyAddress = (apiKey, address) => {
+  const payload = typeof address === 'string' ? { address } : address
+  const url = 'https://api.lob.com/v1/us_verifications'
+  const init = {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${base64.encode(apiKey + ':')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  }
+
+  return fetch(url, init)
+}
+
+export const postVerifyInternationalAddress = (
+  apiKey,
+  address,
+  countryCode
+) => {
+  const url = 'https://api.lob.com/v1/intl_verifications'
+  const init = {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${base64.encode(apiKey + ':')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ address, country: countryCode })
+  }
+
+  return fetch(url, init)
+}

--- a/src/components/AddressAutocomplete.vue
+++ b/src/components/AddressAutocomplete.vue
@@ -1,34 +1,90 @@
 <template>
-  <TypeAhead
-	id="typeahead_id"
-	placeholder="Search for an address"
-	:items="addresses"
-	:minInputLength="1"
-	@selectItem="selectItemEventHandler"
-	@onInput="onInputEventHandler"
->
-</TypeAhead>
+	<div class="demo">
+		<h4>Using a strings array</h4>
+		<div class="row">
+			<div class="column column-60">
+				<span class="float-right">
+					<code>({{ addressesFiltered.length }}/{{ addresses.length }})</code>
+				</span>
+				<TypeAhead :items="addresses" :placeholder="options.placeholder" @selectItem="selectItem" @onInput="onInput" @onBlur="onBlur" :minInputLength="options.minInputLength" :itemProjection="
+						(item) => {
+							return item.label;
+						}
+					" />
+			</div>
+			<div class="column column-40">
+				<pre><code>{{data}}</code></pre>
+			</div>
+		</div>
+	</div>
 </template>
 
 <script>
-import { defineComponent } from 'vue';
 import TypeAhead from './TypeAhead.vue'
-export default defineComponent({
-  component: {
+import { postAutocompleteAddress } from './../api'
+export default {
+  components: {
     TypeAhead
   },
-  data() {
-    return {
-      addresses: []
-  }},
-  methods: {
-    selectItemEventHandler(selectedAddress) {
-      console.log(selectedAddress)
-    },
-    onInputEventHandler(input) {
-      console.log(input)
-
+  props: {
+    apiKey: {
+      type: String
     }
-  }
-})
+  },
+	created() {
+		this.addressesFiltered = this.addresses;
+	},
+	data() {
+		return {
+			options: {
+				placeholder: 'Search for an address',
+				minInputLength: 1,
+			},
+			addresses: [],
+			addressesFiltered: [],
+			data: {
+				input: '',
+				selection: null,
+			},
+		};
+	},
+	methods: {
+		selectItem(item) {
+			this.data.selection = item;
+		},
+		async onInput(event) {
+			this.data.selection = null;
+			this.data.input = event.input;
+			this.addressesFiltered = event.items;
+      const newSuggestions = await this.fetchFromAutocompleteAPI(event.input);
+      this.addresses = newSuggestions;
+		},
+    async fetchFromAutocompleteAPI(userInput) {
+      const newAddresses = await postAutocompleteAddress(this.apiKey, userInput)
+      const newAddressJSON = await newAddresses.json()
+      const suggestions = newAddressJSON['suggestions']
+      const newSuggestions = suggestions.map((x) => ({
+          value: x,
+          label: `${x.primary_line} ${x.city} ${x.state}`
+        }))
+      return newSuggestions
+    },
+
+		onBlur(event) {
+			this.data.input = event.input;
+			this.addressesFiltered = event.items;
+		}
+	},
+};
 </script>
+
+<style>
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 60px;
+}
+</style>

--- a/src/components/AddressAutocomplete.vue
+++ b/src/components/AddressAutocomplete.vue
@@ -1,19 +1,12 @@
 <template>
 	<div class="demo">
-		<h4>Using a strings array</h4>
 		<div class="row">
 			<div class="column column-60">
-				<span class="float-right">
-					<code>({{ addressesFiltered.length }}/{{ addresses.length }})</code>
-				</span>
-				<TypeAhead :items="addresses" :placeholder="options.placeholder" @selectItem="selectItem" @onInput="onInput" @onBlur="onBlur" :minInputLength="options.minInputLength" :itemProjection="
+				<TypeAhead :items="addresses" :placeholder="placeholder" @selectItem="selectItem" @onInput="onInput" @onBlur="onBlur" :minInputLength="minInputLength" :itemProjection="
 						(item) => {
 							return item.label;
 						}
 					" />
-			</div>
-			<div class="column column-40">
-				<pre><code>{{data}}</code></pre>
 			</div>
 		</div>
 	</div>
@@ -23,41 +16,43 @@
 import TypeAhead from './TypeAhead.vue'
 import { postAutocompleteAddress } from './../api'
 export default {
+  //'onInput', 'onFocus', 'onBlur',
+  emits: ['selectItem', 'newSuggestions'],
   components: {
     TypeAhead
   },
   props: {
     apiKey: {
       type: String
+    },
+    addresses: {
+      type: Array
+    },
+    placeholder: {
+      type: String,
+      default: 'Search for an address'
+    },
+    minInputLength: {
+      type: Number,
+      default: 1
     }
   },
-	created() {
-		this.addressesFiltered = this.addresses;
-	},
 	data() {
 		return {
-			options: {
-				placeholder: 'Search for an address',
-				minInputLength: 1,
-			},
-			addresses: [],
-			addressesFiltered: [],
 			data: {
-				input: '',
-				selection: null,
+				input: ''
 			},
 		};
 	},
 	methods: {
 		selectItem(item) {
-			this.data.selection = item;
+			this.$emit('selectItem', item);
 		},
 		async onInput(event) {
 			this.data.selection = null;
 			this.data.input = event.input;
-			this.addressesFiltered = event.items;
       const newSuggestions = await this.fetchFromAutocompleteAPI(event.input);
-      this.addresses = newSuggestions;
+      this.$emit('newSuggestions', newSuggestions);
 		},
     async fetchFromAutocompleteAPI(userInput) {
       const newAddresses = await postAutocompleteAddress(this.apiKey, userInput)
@@ -72,9 +67,8 @@ export default {
 
 		onBlur(event) {
 			this.data.input = event.input;
-			this.addressesFiltered = event.items;
 		}
-	},
+	}
 };
 </script>
 

--- a/src/components/TypeAhead.vue
+++ b/src/components/TypeAhead.vue
@@ -26,9 +26,9 @@
 				@mouseenter="currentSelectionIndex = index"
 			>
 				<span class="simple-typeahead-list-item-text" :data-text="itemProjection(item)" v-if="$slots['list-item-text']"
-					><slot name="list-item-text" :item="item" :itemProjection="itemProjection" :boldMatchText="boldMatchText"></slot
+					><slot name="list-item-text" :item="item" :itemProjection="itemProjection"></slot
 				></span>
-				<span class="simple-typeahead-list-item-text" :data-text="itemProjection(item)" v-html="boldMatchText(itemProjection(item))" v-else></span>
+				<span class="simple-typeahead-list-item-text" :data-text="itemProjection(item)" v-html="itemProjection(item)" v-else></span>
 			</div>
 			<div class="simple-typeahead-list-footer" v-if="$slots['list-footer']"><slot name="list-footer"></slot></div>
 		</div>
@@ -148,8 +148,9 @@
 				return `${this.inputId}_wrapper`;
 			},
 			filteredItems() {
-				const regexp = new RegExp(this.escapeRegExp(this.input), 'i');
-				return this.items.filter((item) => this.itemProjection(item).match(regexp));
+				// const regexp = new RegExp(this.escapeRegExp(this.input), 'i');
+				// return this.items.filter((item) => this.itemProjection(item).match(regexp));
+        return this.items
 			},
 			isListVisible() {
 				return this.isInputFocused && this.input.length >= this.minInputLength && this.filteredItems.length;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import TypeAhead from './components/TypeAhead.vue'
+import AddressAutocomplete from './components/AddressAutocomplete.vue'
 function install(Vue) {
   if (install.installed) {
     return
   }
   install.installed = true
-  Vue.component('TypeAhead', TypeAhead)
+  Vue.component('AddressAutocomplete', AddressAutocomplete)
 }
 
 const plugin = { install }
@@ -22,6 +22,6 @@ if (GlobalVue) {
 
 // Inject install function into component. Allows component to be registered via
 // Vue.use() as well as Vue.component()
-TypeAhead.install = install
+AddressAutocomplete.install = install
 
-export default TypeAhead
+export default AddressAutocomplete

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')


### PR DESCRIPTION
Implements the autocomplete api and the type ahead dropdown is working

There is no styling atm

Updates readme with some basics and links npm to package.json

<img width="1437" alt="Screen Shot 2022-04-02 at 1 46 02 PM" src="https://user-images.githubusercontent.com/38170515/161400666-58e6cca7-2620-4ed9-abdb-fc189f46cd76.png">