### PR TITLE
Minor updates for dev article

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lob/vue-address-autocomplete",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lob/vue-address-autocomplete",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "dependencies": {
                 "base-64": "^1.0.0",
                 "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lob/vue-address-autocomplete",
     "private": false,
-    "version": "1.0.0",
+    "version": "1.0.1",
     "files": [
         "dist"
     ],

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="column-30">
     <div class="flex-row">
-      <AddressAutocomplete class="flex-grow mr-1" :apiKey="apiKey" @selectItem="selectItem" label="Shipping Address" />
+      <AddressAutocomplete
+        :apiKey="apiKey"
+        @onSelectAddress="selectItem"
+        class="flex-grow mr-1"
+        label="Shipping Address"
+      />
       <button @click="handleClick">Verify</button>
     </div>
     <pre>

--- a/src/components/TypeAhead.vue
+++ b/src/components/TypeAhead.vue
@@ -130,8 +130,7 @@
 				this.$emit('onFocus', { input: this.input, items: this.filteredItems });
 			},
 			onBlur() {
-				// Override the input's focused status so users can click the list header
-				this.isInputFocused = true;
+				this.isInputFocused = false;
 				this.$emit('onBlur', { input: this.input, items: this.filteredItems });
 			},
 			onArrowDown($event) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import AddressAutocomplete from './components/AddressAutocomplete.vue'
+
 function install(Vue) {
-  if (install.installed) {
-    return
-  }
-  install.installed = true
-  Vue.component('AddressAutocomplete', AddressAutocomplete)
+    if (install.installed) {
+        return
+    }
+    install.installed = true
+    Vue.component('AddressAutocomplete', AddressAutocomplete)
 }
 
 const plugin = { install }
@@ -12,16 +13,17 @@ const plugin = { install }
 // Auto install if Vue is found
 let GlobalVue
 if (typeof window !== 'undefined') {
-  GlobalVue = window.Vue
+    GlobalVue = window.Vue
 } else if (typeof global !== 'undefined') {
-  GlobalVue = global.Vue
+    GlobalVue = global.Vue
 }
 if (GlobalVue) {
-  GlobalVue.use(plugin)
+    GlobalVue.use(plugin)
 }
 
 // Inject install function into component. Allows component to be registered via
 // Vue.use() as well as Vue.component()
 AddressAutocomplete.install = install
 
+export * from './verify'
 export default AddressAutocomplete


### PR DESCRIPTION
[AV-3265](https://lobsters.atlassian.net/browse/AV-3265)
Found a couple bugs while writing our medium article using vue address autocomplete:
- Verify functions were not being exported
- Updated event names `newSuggestions` and `selectItem` to `onNewSuggestions` and `onSelectAddress`. Using the original event names will print a console warning
- Users were only able to hide the address suggestion list by selecting an address which may not always be ideal