### PR TITLE
Adds new props to for Dashboard integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lob/vue-address-autocomplete",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lob/vue-address-autocomplete",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "dependencies": {
                 "base-64": "^1.0.0",
                 "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@lob/vue-address-autocomplete",
     "private": false,
-    "version": "1.0.2",
+    "version": "1.0.3",
     "files": [
         "dist"
     ],

--- a/src/api.js
+++ b/src/api.js
@@ -4,10 +4,12 @@ import base64 from 'base-64'
 export const postAutocompleteAddress = (
     apiKey,
     addressPrefix,
+    isStaging = false,
     additionalAddressData
 ) => {
+    const domain = isStaging ? 'lob-staging' : 'lob';
     const url =
-        'https://api.lob.com/v1/us_autocompletions?valid_addresses=true&case=proper'
+        `https://api.${domain}.com/v1/us_autocompletions?valid_addresses=true&case=proper`
     const init = {
         method: 'POST',
         headers: {
@@ -27,10 +29,12 @@ export const postAutocompleteInternationalAddress = (
     apiKey,
     addressPrefix,
     country,
+    isStaging = false,
     additionalAddressData
 ) => {
+    const domain = isStaging ? 'lob-staging' : 'lob';
     const url =
-        'https://api.lob.com/v1/intl_autocompletions'
+        `https://api.${domain}.com/v1/intl_autocompletions`
     const init = {
         method: 'POST',
         headers: {
@@ -47,9 +51,10 @@ export const postAutocompleteInternationalAddress = (
     return fetch(url, init)
 }
 
-export const postVerifyAddress = (apiKey, address) => {
+export const postVerifyAddress = (apiKey, address, isStaging = false) => {
     const payload = typeof address === 'string' ? { address } : address
-    const url = 'https://api.lob.com/v1/us_verifications'
+    const domain = isStaging ? 'lob-staging' : 'lob'
+    const url = `https://api.${domain}.com/v1/us_verifications`
     const init = {
         method: 'POST',
         headers: {
@@ -65,9 +70,11 @@ export const postVerifyAddress = (apiKey, address) => {
 export const postVerifyInternationalAddress = (
     apiKey,
     address,
-    countryCode
+    countryCode,
+    isStaging = false
 ) => {
-    const url = 'https://api.lob.com/v1/intl_verifications'
+    const domain = isStaging ? 'lob-staging' : 'lob'
+    const url = `https://api.${domain}.com/v1/intl_verifications`
     const init = {
         method: 'POST',
         headers: {

--- a/src/components/AddressAutocomplete.vue
+++ b/src/components/AddressAutocomplete.vue
@@ -157,6 +157,14 @@ export default {
         return [];
       }
 
+      if ('primary_line' in this.address) {
+        delete this.address.primary_line;
+      }
+
+      if ('secondary_line' in this.address) {
+        delete this.address.secondary_line;
+      }
+
       const newAddresses = this.isInternational
         ? await postAutocompleteInternationalAddress(this.apiKey, userInput, this.country, this.isStaging)
         : await postAutocompleteAddress(this.apiKey, userInput, this.isStaging, this.address)

--- a/src/components/AddressAutocomplete.vue
+++ b/src/components/AddressAutocomplete.vue
@@ -35,6 +35,14 @@ export default {
     TypeAhead
   },
   props: {
+    /**
+     * Address components for more specific suggestions. Primarily used when primaryLineOnly is
+     * true and for US autocomplete only
+     */
+    address: {
+      type: Object,
+      default: {}
+    },
     apiKey: {
       type: String
     },
@@ -43,6 +51,10 @@ export default {
       default: 'US'
     },
     isInternational: {
+      type: Boolean,
+      default: false
+    },
+    isStaging: {
       type: Boolean,
       default: false
     },
@@ -146,8 +158,8 @@ export default {
       }
 
       const newAddresses = this.isInternational
-        ? await postAutocompleteInternationalAddress(this.apiKey, userInput, this.country)
-        : await postAutocompleteAddress(this.apiKey, userInput)
+        ? await postAutocompleteInternationalAddress(this.apiKey, userInput, this.country, this.isStaging)
+        : await postAutocompleteAddress(this.apiKey, userInput, this.isStaging, this.address)
       const newAddressJSON = await newAddresses.json()
 
       if (newAddressJSON.error) {

--- a/src/components/TypeAhead.vue
+++ b/src/components/TypeAhead.vue
@@ -1,15 +1,15 @@
 <template>
 	<div :id="wrapperId" class="lob-typeahead-root">
-		<div v-if="label" class="lob-typeahead-label" :class="!isLabelFloating ? 'lob-typeahead-label-absolute' : 'lob-typeahead-label-floating'">
+		<label :for="inputId" v-if="label" class="lob-typeahead-label" :class="!isLabelFloating ? 'lob-typeahead-label-absolute' : 'lob-typeahead-label-floating'">
 			{{label}}
-		</div>
+		</label>
 		<input
 			:id="inputId"
 			class="lob-typeahead-input"
 			:class="label && !isLabelFloating && 'lob-typeahead-input-with-label'"
 			type="text"
 			:placeholder="placeholder"
-			v-model="input"
+			v-model="modelValue"
 			@input="onInput"
 			@focus="onFocus"
 			@blur="onBlur"
@@ -104,6 +104,10 @@
 				type: String,
 				default: null
 			},
+			modelValue: {
+				type: String,
+				default: ''
+			},
 			isLabelFloating: {
 				type: Boolean,
 				default: false
@@ -117,25 +121,25 @@
 		data() {
 			return {
 				inputId: this.id || `simple_typeahead_${(Math.random() * 1000).toFixed()}`,
-				input: '',
 				isInputFocused: false,
 				currentSelectionIndex: 0,
 			};
 		},
 		methods: {
-			onInput() {
+			onInput(e) {
 				if (this.isListVisible && this.currentSelectionIndex >= this.filteredItems.length) {
 					this.currentSelectionIndex = (this.filteredItems.length || 1) - 1;
 				}
-				this.$emit('onInput', { input: this.input, items: this.filteredItems });
+				this.$emit('onInput', { input: this.modelValue, items: this.filteredItems });
+				this.$emit('update:modelValue', e.target.value)
 			},
 			onFocus() {
 				this.isInputFocused = true;
-				this.$emit('onFocus', { input: this.input, items: this.filteredItems });
+				this.$emit('onFocus', { input: this.modelValue, items: this.filteredItems });
 			},
 			onBlur() {
 				this.isInputFocused = false;
-				this.$emit('onBlur', { input: this.input, items: this.filteredItems });
+				this.$emit('onBlur', { input: this.modelValue, items: this.filteredItems });
 			},
 			onArrowDown($event) {
 				if (this.isListVisible && this.currentSelectionIndex < this.filteredItems.length - 1) {
@@ -171,7 +175,7 @@
 			},
 			selectItem(item) {
 				this.$emit('selectItem', item);
-				this.input = this.itemProjection(item).input;
+				this.$emit('update:modelValue', this.itemProjection(item).input);
 				this.currentSelectionIndex = 0;
 				document.getElementById(this.inputId)?.blur();
 				this.isInputFocused = false;
@@ -180,7 +184,7 @@
 				return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 			},
 			boldMatchText(text) {
-				const regexp = new RegExp(`(${this.escapeRegExp(this.input)})`, 'ig');
+				const regexp = new RegExp(`(${this.escapeRegExp(this.modelValue)})`, 'ig');
 				return text.replace(regexp, '<strong>$1</strong>');
 			},
 		},
@@ -189,13 +193,13 @@
 				return `${this.inputId}_wrapper`;
 			},
 			filteredItems() {
-				// const regexp = new RegExp(this.escapeRegExp(this.input), 'i');
+				// const regexp = new RegExp(this.escapeRegExp(this.modelValue), 'i');
 				// return this.items.filter((item) => this.itemProjection(item).match(regexp));
         return this.items || []
 			},
 			isListVisible() {
 				// Allow empty inputs from test cases
-				const isInputValid = process.env.NODE_ENV === 'test' || this.input.length >= this.minInputLength
+				const isInputValid = process.env.NODE_ENV === 'test' || this.modelValue.length >= this.minInputLength
 				return this.isInputFocused && isInputValid && this.filteredItems.length;
 			},
 			currentSelection() {

--- a/src/components/TypeAhead.vue
+++ b/src/components/TypeAhead.vue
@@ -1,12 +1,12 @@
 <template>
 	<div :id="wrapperId" class="lob-typeahead-root">
-		<div v-if="label" class="lob-typeahead-label">
+		<div v-if="label" class="lob-typeahead-label" :class="!isLabelFloating ? 'lob-typeahead-label-absolute' : 'lob-typeahead-label-floating'">
 			{{label}}
 		</div>
 		<input
 			:id="inputId"
 			class="lob-typeahead-input"
-			:class="label && 'lob-typeahead-input-with-label'"
+			:class="label && !isLabelFloating && 'lob-typeahead-input-with-label'"
 			type="text"
 			:placeholder="placeholder"
 			v-model="input"
@@ -103,6 +103,10 @@
 			label: {
 				type: String,
 				default: null
+			},
+			isLabelFloating: {
+				type: Boolean,
+				default: false
 			}
 		},
 		mounted() {
@@ -244,9 +248,14 @@
 		font-size: 14px;
 		font-weight: 400;
 		color: var(--lob-label-text-color);
+	}
+	.lob-typeahead-label-absolute {
 		position: absolute;
     left: 1em;
     top: 0.5em;
+	}
+	.lob-typeahead-label-floating {
+		margin-bottom: 0.5rem;
 	}
 	.lob-typeahead-list {
 		background: var(--lob-suggestion-item-background-color);


### PR DESCRIPTION
[AV-3253](https://lobsters.atlassian.net/browse/AV-3253)
[AV-3254](https://lobsters.atlassian.net/browse/AV-3254)

Came across a couple improvements while adding AddressAutocomplete to our dashboard
- Adds `AddressAutocomplete` prop `isStaging` to toggle between Lob's staging API and prod
- Adds `TypeAhead` prop `isLabelFloating` which will render the label above the input instead of inside (propagated by `AddressAutocomplete`)
- Adds `AddressAutocomplete` prop `address` which accepts address components for more precise US suggestions